### PR TITLE
Read photodiode data from page 0x00

### DIFF
--- a/06/aqi5_test.py
+++ b/06/aqi5_test.py
@@ -122,7 +122,8 @@ with SMBus(1) as bus:
 
     while True:
         try:
-            set_page(bus, 0x01)
+            # Page 0x00 contains the photodiode data registers
+            set_page(bus, 0x00)
             time.sleep(0.05)
             for reg in range(0x0064, 0x0068):
                 val = read_reg16(bus, reg)

--- a/06/smoketest.py
+++ b/06/smoketest.py
@@ -126,7 +126,8 @@ with SMBus(1) as bus:
 
     while True:
         try:
-            set_page(bus, 0x01)
+            # Page 0x00 contains the photodiode data registers
+            set_page(bus, 0x00)
             time.sleep(0.05)
             for reg in range(0x0064, 0x0068):
                 val = read_reg16(bus, reg)

--- a/smoketest-limited.py
+++ b/smoketest-limited.py
@@ -126,7 +126,8 @@ with SMBus(1) as bus:
 
     while True:
         try:
-            set_page(bus, 0x01)
+            # Page 0x00 contains the photodiode data registers
+            set_page(bus, 0x00)
             time.sleep(0.05)
             for reg in range(0x0064, 0x0068):
                 val = read_reg16(bus, reg)


### PR DESCRIPTION
## Summary
- adjust the readout loop to select page `0x00` before reading registers `0x64-0x67`
- apply change across smoketest scripts

## Testing
- `python3 -m py_compile smoketest-limited.py 06/smoketest.py 06/aqi5_test.py`

------
https://chatgpt.com/codex/tasks/task_e_686575e744bc832b8d72088759839caa