### PR TITLE
Implement MikroE default configuration

### DIFF
--- a/06/aqi5_test.py
+++ b/06/aqi5_test.py
@@ -1,134 +1,154 @@
-# Smoke 2 Click (ADPD188BI) – Direct I2C Config + Read in Python
-
 from smbus2 import SMBus
 import time
 
-I2C_ADDR = 0x64  # Smoke 2 Click (ADPD188BI) default address
+I2C_ADDR = 0x64
 
-# Register map from ADPD188BI datasheet
-REG_SYS_CTL     = 0x0000
-REG_OP_MODE     = 0x0001
-REG_INT_MASK    = 0x0020
-REG_INT_STATUS  = 0x0021
-REG_SLOT_EN     = 0x0040
-REG_PD_LED_SELECT = 0x004F
-REG_CH1         = 0x0014
-REG_CH2         = 0x0016
+# Register addresses (8-bit from MikroElektronika driver)
+REG_STATUS              = 0x00
+REG_INT_MASK            = 0x01
+REG_GPIO_DRV            = 0x02
+REG_SW_RESET            = 0x0F
+REG_MODE                = 0x10
+REG_SLOT_EN             = 0x11
+REG_FSAMPLE             = 0x12
+REG_PD_LED_SELECT       = 0x14
+REG_NUM_AVG             = 0x15
+REG_INT_SEQ_A           = 0x17
+REG_SLOTA_CH1_OFFSET    = 0x18
+REG_SLOTA_CH2_OFFSET    = 0x19
+REG_SLOTA_CH3_OFFSET    = 0x1A
+REG_SLOTA_CH4_OFFSET    = 0x1B
+REG_INT_SEQ_B           = 0x1D
+REG_SLOTB_CH1_OFFSET    = 0x1E
+REG_SLOTB_CH2_OFFSET    = 0x1F
+REG_SLOTB_CH3_OFFSET    = 0x20
+REG_SLOTB_CH4_OFFSET    = 0x21
+REG_ILED3_COARSE        = 0x22
+REG_ILED1_COARSE        = 0x23
+REG_ILED2_COARSE        = 0x24
+REG_ILED_FINE           = 0x25
+REG_SLOTA_LED_PULSE     = 0x30
+REG_SLOTA_NUM_PULSES    = 0x31
+REG_SLOTB_LED_PULSE     = 0x35
+REG_SLOTB_NUM_PULSES    = 0x36
+REG_SLOTA_AFE_WINDOW    = 0x39
+REG_SLOTB_AFE_WINDOW    = 0x3B
+REG_AFE_PWR_CFG1        = 0x3C
+REG_SLOTA_TIA_CFG       = 0x42
+REG_SLOTA_AFE_CFG       = 0x43
+REG_SLOTB_TIA_CFG       = 0x44
+REG_SLOTB_AFE_CFG       = 0x45
+REG_AFE_PWR_CFG2        = 0x54
+REG_MATH                = 0x58
+REG_DATA_ACCESS_CTL     = 0x5F
+REG_SLOTA_CH1           = 0x64
+REG_SLOTA_CH2           = 0x65
+REG_SLOTA_CH3           = 0x66
+REG_SLOTA_CH4           = 0x67
 
-# Helper: set register page
-REG_PAGE_SEL = 0x000F
+# Basic register helpers
 
-def set_page(bus, page):
-    bus.write_i2c_block_data(I2C_ADDR, REG_PAGE_SEL >> 8, [REG_PAGE_SEL & 0xFF, 0x00, page])
-    time.sleep(0.01)
-
-# Helper: write 16-bit to 16-bit register
 def write_reg16(bus, reg, value):
-    data = [(value >> 8) & 0xFF, value & 0xFF]
-    bus.write_i2c_block_data(I2C_ADDR, reg >> 8, [reg & 0xFF] + data)
+    bus.write_i2c_block_data(I2C_ADDR, reg, [value >> 8, value & 0xFF])
 
-# Helper: read 16-bit from 16-bit register
+
 def read_reg16(bus, reg):
-    bus.write_i2c_block_data(I2C_ADDR, reg >> 8, [reg & 0xFF])
-    time.sleep(0.01)
-    result = bus.read_i2c_block_data(I2C_ADDR, reg >> 8, 2)
-    return (result[0] << 8) | result[1]
+    data = bus.read_i2c_block_data(I2C_ADDR, reg, 2)
+    return (data[0] << 8) | data[1]
+
+
+def set_bit(bus, reg, bit, val):
+    tmp = read_reg16(bus, reg)
+    if val:
+        tmp |= (1 << bit)
+    else:
+        tmp &= ~(1 << bit)
+    write_reg16(bus, reg, tmp)
+
+
+def soft_reset(bus):
+    write_reg16(bus, REG_SW_RESET, 0x0001)
+    time.sleep(0.1)
+
+
+def set_mode(bus, mode):
+    write_reg16(bus, REG_MODE, mode & 0x03)
+
+
+def default_cfg(bus):
+    sequence = [
+        (REG_SLOT_EN, 0x30A9),
+        (REG_FSAMPLE, 0x0200),
+        (REG_PD_LED_SELECT, 0x011D),
+        (REG_NUM_AVG, 0x0000),
+        (REG_INT_SEQ_A, 0x0009),
+        (REG_SLOTA_CH1_OFFSET, 0x0000),
+        (REG_SLOTA_CH2_OFFSET, 0x3FFF),
+        (REG_SLOTA_CH3_OFFSET, 0x3FFF),
+        (REG_SLOTA_CH4_OFFSET, 0x3FFF),
+        (REG_INT_SEQ_B, 0x0009),
+        (REG_SLOTB_CH1_OFFSET, 0x0000),
+        (REG_SLOTB_CH2_OFFSET, 0x3FFF),
+        (REG_SLOTB_CH3_OFFSET, 0x3FFF),
+        (REG_SLOTB_CH4_OFFSET, 0x3FFF),
+        (REG_ILED3_COARSE, 0x3539),
+        (REG_ILED1_COARSE, 0x3536),
+        (REG_ILED2_COARSE, 0x1530),
+        (REG_ILED_FINE, 0x630C),
+        (REG_SLOTA_LED_PULSE, 0x0320),
+        (REG_SLOTA_NUM_PULSES, 0x040E),
+        (REG_SLOTB_LED_PULSE, 0x0320),
+        (REG_SLOTB_NUM_PULSES, 0x040E),
+        (REG_SLOTA_AFE_WINDOW, 0x22F0),
+        (REG_SLOTB_AFE_WINDOW, 0x22F0),
+        (REG_AFE_PWR_CFG1, 0x31C6),
+        (REG_SLOTA_TIA_CFG, 0x1C34),
+        (REG_SLOTA_AFE_CFG, 0xADA5),
+        (REG_SLOTB_TIA_CFG, 0x1C34),
+        (REG_SLOTB_AFE_CFG, 0xADA5),
+        (REG_MATH, 0x0544),
+        (REG_AFE_PWR_CFG2, 0x0AA0),
+        (REG_DATA_ACCESS_CTL, 0x0007),
+    ]
+    for reg, val in sequence:
+        write_reg16(bus, reg, val)
+
+    set_mode(bus, 1)  # program mode
+    set_bit(bus, 0x4B, 7, 1)  # SAMPLE_CLK bit 7
+    set_bit(bus, REG_DATA_ACCESS_CTL, 0, 1)
+    set_bit(bus, REG_INT_MASK, 5, 0)
+    set_bit(bus, REG_INT_MASK, 6, 1)
+    set_bit(bus, REG_INT_MASK, 8, 1)
+    set_bit(bus, REG_GPIO_DRV, 0, 1)
+    set_bit(bus, REG_GPIO_DRV, 1, 1)
+    set_bit(bus, REG_GPIO_DRV, 2, 1)
+    write_reg16(bus, REG_SLOT_EN, 0x3001)
+    set_mode(bus, 2)  # normal mode
+
+
+def read_slot_a(bus):
+    # enable data access for slot A
+    set_bit(bus, REG_DATA_ACCESS_CTL, 1, 1)
+    values = [read_reg16(bus, reg) for reg in (REG_SLOTA_CH1, REG_SLOTA_CH2,
+                                               REG_SLOTA_CH3, REG_SLOTA_CH4)]
+    set_bit(bus, REG_DATA_ACCESS_CTL, 1, 0)
+    return values
+
 
 with SMBus(1) as bus:
     print("Initializing Smoke 2 Click (ADPD188BI)...")
-
-    # ----------------------
-    # PAGE 0x00 – Reset + Program Mode
-    # ----------------------
-    set_page(bus, 0x00)
-    write_reg16(bus, REG_SYS_CTL, 0x0002)  # Soft reset
-    time.sleep(0.1)
-    write_reg16(bus, REG_OP_MODE, 0x0002)  # Program mode
-    time.sleep(0.05)
-
-    # ----------------------
-    # PAGE 0x01 – LED + Signal Chain Config (Minimal Clock + LED Init)
-    # ----------------------
-    set_page(bus, 0x01)
-    time.sleep(0.01)
-    write_reg16(bus, 0x0100, 0x1010)  # Shorter pulse width
-    write_reg16(bus, 0x0101, 0x1010)  # Moderate LED current
-    write_reg16(bus, 0x0102, 0x0008)  # Fewer pulses
-    write_reg16(bus, 0x0103, 0x0001)  # Sample every cycle  # Sample freq
-    time.sleep(0.01)
-
-    write_reg16(bus, 0x0053, 0x0001)  # LED pulse count
-    write_reg16(bus, 0x0054, 0x0001)  # LED offset
-    write_reg16(bus, 0x0104, 0x0003)  # Minimal viable clock bits
-    val = read_reg16(bus, 0x0104)
-    print(f"Post-write clock register 0x0104: 0x{val:04X}")  # Clock settings
-
-    write_reg16(bus, 0x004F, 0x0030)  # IR + GREEN
-    write_reg16(bus, 0x0050, 0x0001)  # Repeat LED1
-    write_reg16(bus, 0x0051, 0x0001)  # Repeat LED2
-    write_reg16(bus, 0x0052, 0x0001)  # Repeat LED3
-    time.sleep(0.01)
-
-    # ----------------------
-    # SLOT A Setup
-    # ----------------------
-    write_reg16(bus, 0x0110, 0x0010)  # Slot A Start
-    write_reg16(bus, 0x0111, 0x0040)  # Slot A End
-    write_reg16(bus, 0x0112, 0x0003)  # Enable Ch1 + Ch2
-    write_reg16(bus, 0x0040, 0x0001)  # Enable Slot A
-
-    # ----------------------
-    # PAGE 0x02 – AFE + Offset
-    # ----------------------
-    set_page(bus, 0x02)
-    time.sleep(0.01)
-    write_reg16(bus, 0x0200, 0x0000)  # AFE offset
-    write_reg16(bus, 0x0201, 0x0002)  # Gain = 100k
-
-    # ----------------------
-    # PAGE 0x01 – FIFO, Interrupt, Output Buffers
-    # ----------------------
-    set_page(bus, 0x01)
-    time.sleep(0.01)
-    write_reg16(bus, 0x0004, 0x0019)  # FIFO config
-    write_reg16(bus, 0x0006, 0x0400)  # Decimation
-    write_reg16(bus, 0x010A, 0x0000)  # Force register mode instead of FIFO  # Output buffer config
-    write_reg16(bus, 0x010B, 0x0001)
-    write_reg16(bus, 0x0020, 0x8000)  # Clear INT mask
-    write_reg16(bus, 0x0021, 0x8000)  # Clear INT status
-    write_reg16(bus, 0x000F, 0x0001)  # Page again
-    write_reg16(bus, REG_PD_LED_SELECT, 0x0030)
-
-    # ----------------------
-    # PAGE 0x00 – Start Sampling
-    # ----------------------
-    set_page(bus, 0x00)
-    time.sleep(0.01)
-    write_reg16(bus, REG_OP_MODE, 0x0001)  # Normal sampling
-    time.sleep(0.1)
-
-    # ----------------------
-    # Begin Readout
-    # ----------------------
-    set_page(bus, 0x02)
-    print("Reading Smoke Sensor Values:")
-    current_mode = read_reg16(bus, REG_OP_MODE)
-    print(f"REG_OP_MODE current value: 0x{current_mode:04X}")
-    fifo_count = read_reg16(bus, 0x0000)
-    print(f"FIFO Samples (from 0x0000 upper byte): {(fifo_count >> 8) & 0xFF}")
-    int_status = read_reg16(bus, 0x0021)
-    print(f"INT_STATUS: 0x{int_status:04X}")
-    print("Reading registers 0x0064 to 0x0067...")
+    soft_reset(bus)
+    set_mode(bus, 0)  # idle
+    devid = read_reg16(bus, 0x08)
+    print(f"Device ID: 0x{devid:04X}")
+    default_cfg(bus)
+    print("Starting readout...")
 
     while True:
         try:
-            set_page(bus, 0x01)
-            time.sleep(0.05)
-            for reg in range(0x0064, 0x0068):
-                val = read_reg16(bus, reg)
-                print(f"0x{reg:04X}: {val}", end='  ')
-            print("")
+            vals = read_slot_a(bus)
+            print("CH1=%d  CH2=%d  CH3=%d  CH4=%d" % tuple(vals))
         except Exception as e:
             print(f"Error reading sensor: {e}")
-
         time.sleep(2)
+

--- a/06/smoketest.py
+++ b/06/smoketest.py
@@ -1,138 +1,154 @@
-# Smoke 2 Click (ADPD188BI) – Direct I2C Config + Read in Python
-#codex
 from smbus2 import SMBus
 import time
 
-I2C_ADDR = 0x64  # Smoke 2 Click (ADPD188BI) default address
+I2C_ADDR = 0x64
 
-# Register map from ADPD188BI datasheet
-REG_SYS_CTL     = 0x0000
-REG_OP_MODE     = 0x0001
-REG_INT_MASK    = 0x0020
-REG_INT_STATUS  = 0x0021
-REG_SLOT_EN     = 0x0040
-REG_PD_LED_SELECT = 0x004F
-REG_CH1         = 0x0014
-REG_CH2         = 0x0016
+# Register addresses (8-bit from MikroElektronika driver)
+REG_STATUS              = 0x00
+REG_INT_MASK            = 0x01
+REG_GPIO_DRV            = 0x02
+REG_SW_RESET            = 0x0F
+REG_MODE                = 0x10
+REG_SLOT_EN             = 0x11
+REG_FSAMPLE             = 0x12
+REG_PD_LED_SELECT       = 0x14
+REG_NUM_AVG             = 0x15
+REG_INT_SEQ_A           = 0x17
+REG_SLOTA_CH1_OFFSET    = 0x18
+REG_SLOTA_CH2_OFFSET    = 0x19
+REG_SLOTA_CH3_OFFSET    = 0x1A
+REG_SLOTA_CH4_OFFSET    = 0x1B
+REG_INT_SEQ_B           = 0x1D
+REG_SLOTB_CH1_OFFSET    = 0x1E
+REG_SLOTB_CH2_OFFSET    = 0x1F
+REG_SLOTB_CH3_OFFSET    = 0x20
+REG_SLOTB_CH4_OFFSET    = 0x21
+REG_ILED3_COARSE        = 0x22
+REG_ILED1_COARSE        = 0x23
+REG_ILED2_COARSE        = 0x24
+REG_ILED_FINE           = 0x25
+REG_SLOTA_LED_PULSE     = 0x30
+REG_SLOTA_NUM_PULSES    = 0x31
+REG_SLOTB_LED_PULSE     = 0x35
+REG_SLOTB_NUM_PULSES    = 0x36
+REG_SLOTA_AFE_WINDOW    = 0x39
+REG_SLOTB_AFE_WINDOW    = 0x3B
+REG_AFE_PWR_CFG1        = 0x3C
+REG_SLOTA_TIA_CFG       = 0x42
+REG_SLOTA_AFE_CFG       = 0x43
+REG_SLOTB_TIA_CFG       = 0x44
+REG_SLOTB_AFE_CFG       = 0x45
+REG_AFE_PWR_CFG2        = 0x54
+REG_MATH                = 0x58
+REG_DATA_ACCESS_CTL     = 0x5F
+REG_SLOTA_CH1           = 0x64
+REG_SLOTA_CH2           = 0x65
+REG_SLOTA_CH3           = 0x66
+REG_SLOTA_CH4           = 0x67
 
-# Helper: set register page
-REG_PAGE_SEL = 0x000F
-
-def set_page(bus, page):
-    bus.write_i2c_block_data(I2C_ADDR, REG_PAGE_SEL >> 8, [REG_PAGE_SEL & 0xFF, 0x00, page])
-    time.sleep(0.01)
-
-# Helper: write 16-bit to 16-bit register
-from smbus2 import i2c_msg
+# Basic register helpers
 
 def write_reg16(bus, reg, value):
-    data = [reg >> 8, reg & 0xFF, value >> 8, value & 0xFF]
-    msg = i2c_msg.write(I2C_ADDR, data)
-    bus.i2c_rdwr(msg)
+    bus.write_i2c_block_data(I2C_ADDR, reg, [value >> 8, value & 0xFF])
 
-# Helper: read 16-bit from 16-bit register
+
 def read_reg16(bus, reg):
-    write = i2c_msg.write(I2C_ADDR, [reg >> 8, reg & 0xFF])
-    read = i2c_msg.read(I2C_ADDR, 2)
-    bus.i2c_rdwr(write, read)
-    res = list(read)
-    return (res[0] << 8) | res[1]
+    data = bus.read_i2c_block_data(I2C_ADDR, reg, 2)
+    return (data[0] << 8) | data[1]
+
+
+def set_bit(bus, reg, bit, val):
+    tmp = read_reg16(bus, reg)
+    if val:
+        tmp |= (1 << bit)
+    else:
+        tmp &= ~(1 << bit)
+    write_reg16(bus, reg, tmp)
+
+
+def soft_reset(bus):
+    write_reg16(bus, REG_SW_RESET, 0x0001)
+    time.sleep(0.1)
+
+
+def set_mode(bus, mode):
+    write_reg16(bus, REG_MODE, mode & 0x03)
+
+
+def default_cfg(bus):
+    sequence = [
+        (REG_SLOT_EN, 0x30A9),
+        (REG_FSAMPLE, 0x0200),
+        (REG_PD_LED_SELECT, 0x011D),
+        (REG_NUM_AVG, 0x0000),
+        (REG_INT_SEQ_A, 0x0009),
+        (REG_SLOTA_CH1_OFFSET, 0x0000),
+        (REG_SLOTA_CH2_OFFSET, 0x3FFF),
+        (REG_SLOTA_CH3_OFFSET, 0x3FFF),
+        (REG_SLOTA_CH4_OFFSET, 0x3FFF),
+        (REG_INT_SEQ_B, 0x0009),
+        (REG_SLOTB_CH1_OFFSET, 0x0000),
+        (REG_SLOTB_CH2_OFFSET, 0x3FFF),
+        (REG_SLOTB_CH3_OFFSET, 0x3FFF),
+        (REG_SLOTB_CH4_OFFSET, 0x3FFF),
+        (REG_ILED3_COARSE, 0x3539),
+        (REG_ILED1_COARSE, 0x3536),
+        (REG_ILED2_COARSE, 0x1530),
+        (REG_ILED_FINE, 0x630C),
+        (REG_SLOTA_LED_PULSE, 0x0320),
+        (REG_SLOTA_NUM_PULSES, 0x040E),
+        (REG_SLOTB_LED_PULSE, 0x0320),
+        (REG_SLOTB_NUM_PULSES, 0x040E),
+        (REG_SLOTA_AFE_WINDOW, 0x22F0),
+        (REG_SLOTB_AFE_WINDOW, 0x22F0),
+        (REG_AFE_PWR_CFG1, 0x31C6),
+        (REG_SLOTA_TIA_CFG, 0x1C34),
+        (REG_SLOTA_AFE_CFG, 0xADA5),
+        (REG_SLOTB_TIA_CFG, 0x1C34),
+        (REG_SLOTB_AFE_CFG, 0xADA5),
+        (REG_MATH, 0x0544),
+        (REG_AFE_PWR_CFG2, 0x0AA0),
+        (REG_DATA_ACCESS_CTL, 0x0007),
+    ]
+    for reg, val in sequence:
+        write_reg16(bus, reg, val)
+
+    set_mode(bus, 1)  # program mode
+    set_bit(bus, 0x4B, 7, 1)  # SAMPLE_CLK bit 7
+    set_bit(bus, REG_DATA_ACCESS_CTL, 0, 1)
+    set_bit(bus, REG_INT_MASK, 5, 0)
+    set_bit(bus, REG_INT_MASK, 6, 1)
+    set_bit(bus, REG_INT_MASK, 8, 1)
+    set_bit(bus, REG_GPIO_DRV, 0, 1)
+    set_bit(bus, REG_GPIO_DRV, 1, 1)
+    set_bit(bus, REG_GPIO_DRV, 2, 1)
+    write_reg16(bus, REG_SLOT_EN, 0x3001)
+    set_mode(bus, 2)  # normal mode
+
+
+def read_slot_a(bus):
+    # enable data access for slot A
+    set_bit(bus, REG_DATA_ACCESS_CTL, 1, 1)
+    values = [read_reg16(bus, reg) for reg in (REG_SLOTA_CH1, REG_SLOTA_CH2,
+                                               REG_SLOTA_CH3, REG_SLOTA_CH4)]
+    set_bit(bus, REG_DATA_ACCESS_CTL, 1, 0)
+    return values
+
 
 with SMBus(1) as bus:
     print("Initializing Smoke 2 Click (ADPD188BI)...")
-
-    # ----------------------
-    # PAGE 0x00 – Reset + Program Mode
-    # ----------------------
-    set_page(bus, 0x00)
-    write_reg16(bus, REG_SYS_CTL, 0x0002)  # Soft reset
-    time.sleep(0.1)
-    write_reg16(bus, REG_OP_MODE, 0x0002)  # Program mode
-    time.sleep(0.05)
-
-    # ----------------------
-    # PAGE 0x01 – LED + Signal Chain Config (Minimal Clock + LED Init)
-    # ----------------------
-    set_page(bus, 0x01)
-    time.sleep(0.01)
-    write_reg16(bus, 0x0100, 0x1010)  # Shorter pulse width
-    write_reg16(bus, 0x0101, 0x1010)  # Moderate LED current
-    write_reg16(bus, 0x0102, 0x0008)  # Fewer pulses
-    write_reg16(bus, 0x0103, 0x0001)  # Sample every cycle  # Sample freq
-    time.sleep(0.01)
-
-    write_reg16(bus, 0x0053, 0x0001)  # LED pulse count
-    write_reg16(bus, 0x0054, 0x0001)  # LED offset
-    write_reg16(bus, 0x0104, 0x0003)  # Minimal viable clock bits
-    val = read_reg16(bus, 0x0104)
-    print(f"Post-write clock register 0x0104: 0x{val:04X}")  # Clock settings
-
-    write_reg16(bus, 0x004F, 0x0030)  # IR + GREEN
-    write_reg16(bus, 0x0050, 0x0001)  # Repeat LED1
-    write_reg16(bus, 0x0051, 0x0001)  # Repeat LED2
-    write_reg16(bus, 0x0052, 0x0001)  # Repeat LED3
-    time.sleep(0.01)
-
-    # ----------------------
-    # SLOT A Setup
-    # ----------------------
-    write_reg16(bus, 0x0110, 0x0010)  # Slot A Start
-    write_reg16(bus, 0x0111, 0x0040)  # Slot A End
-    write_reg16(bus, 0x0112, 0x0003)  # Enable Ch1 + Ch2
-    write_reg16(bus, 0x0040, 0x0001)  # Enable Slot A
-
-    # ----------------------
-    # PAGE 0x02 – AFE + Offset
-    # ----------------------
-    set_page(bus, 0x02)
-    time.sleep(0.01)
-    write_reg16(bus, 0x0200, 0x0000)  # AFE offset
-    write_reg16(bus, 0x0201, 0x0002)  # Gain = 100k
-
-    # ----------------------
-    # PAGE 0x01 – FIFO, Interrupt, Output Buffers
-    # ----------------------
-    set_page(bus, 0x01)
-    time.sleep(0.01)
-    write_reg16(bus, 0x0004, 0x0019)  # FIFO config
-    write_reg16(bus, 0x0006, 0x0400)  # Decimation
-    write_reg16(bus, 0x010A, 0x0000)  # Force register mode instead of FIFO  # Output buffer config
-    write_reg16(bus, 0x010B, 0x0001)
-    write_reg16(bus, 0x0020, 0x8000)  # Clear INT mask
-    write_reg16(bus, 0x0021, 0x8000)  # Clear INT status
-    write_reg16(bus, 0x000F, 0x0001)  # Page again
-    write_reg16(bus, REG_PD_LED_SELECT, 0x0030)
-
-    # ----------------------
-    # PAGE 0x00 – Start Sampling
-    # ----------------------
-    set_page(bus, 0x00)
-    time.sleep(0.01)
-    write_reg16(bus, REG_OP_MODE, 0x0001)  # Normal sampling
-    time.sleep(0.1)
-
-    # ----------------------
-    # Begin Readout
-    # ----------------------
-    set_page(bus, 0x02)
-    print("Reading Smoke Sensor Values:")
-    current_mode = read_reg16(bus, REG_OP_MODE)
-    print(f"REG_OP_MODE current value: 0x{current_mode:04X}")
-    fifo_count = read_reg16(bus, 0x0000)
-    print(f"FIFO Samples (from 0x0000 upper byte): {(fifo_count >> 8) & 0xFF}")
-    int_status = read_reg16(bus, 0x0021)
-    print(f"INT_STATUS: 0x{int_status:04X}")
-    print("Reading registers 0x0064 to 0x0067...")
+    soft_reset(bus)
+    set_mode(bus, 0)  # idle
+    devid = read_reg16(bus, 0x08)
+    print(f"Device ID: 0x{devid:04X}")
+    default_cfg(bus)
+    print("Starting readout...")
 
     while True:
         try:
-            set_page(bus, 0x01)
-            time.sleep(0.05)
-            for reg in range(0x0064, 0x0068):
-                val = read_reg16(bus, reg)
-                print(f"0x{reg:04X}: {val}", end='  ')
-            print("")
+            vals = read_slot_a(bus)
+            print("CH1=%d  CH2=%d  CH3=%d  CH4=%d" % tuple(vals))
         except Exception as e:
             print(f"Error reading sensor: {e}")
-
         time.sleep(2)
+

--- a/smoketest-limited.py
+++ b/smoketest-limited.py
@@ -1,138 +1,154 @@
-# Smoke 2 Click (ADPD188BI) – Direct I2C Config + Read in Python
-
 from smbus2 import SMBus
 import time
 
-I2C_ADDR = 0x64  # Smoke 2 Click (ADPD188BI) default address
+I2C_ADDR = 0x64
 
-# Register map from ADPD188BI datasheet
-REG_SYS_CTL     = 0x0000
-REG_OP_MODE     = 0x0001
-REG_INT_MASK    = 0x0020
-REG_INT_STATUS  = 0x0021
-REG_SLOT_EN     = 0x0040
-REG_PD_LED_SELECT = 0x004F
-REG_CH1         = 0x0014
-REG_CH2         = 0x0016
+# Register addresses (8-bit from MikroElektronika driver)
+REG_STATUS              = 0x00
+REG_INT_MASK            = 0x01
+REG_GPIO_DRV            = 0x02
+REG_SW_RESET            = 0x0F
+REG_MODE                = 0x10
+REG_SLOT_EN             = 0x11
+REG_FSAMPLE             = 0x12
+REG_PD_LED_SELECT       = 0x14
+REG_NUM_AVG             = 0x15
+REG_INT_SEQ_A           = 0x17
+REG_SLOTA_CH1_OFFSET    = 0x18
+REG_SLOTA_CH2_OFFSET    = 0x19
+REG_SLOTA_CH3_OFFSET    = 0x1A
+REG_SLOTA_CH4_OFFSET    = 0x1B
+REG_INT_SEQ_B           = 0x1D
+REG_SLOTB_CH1_OFFSET    = 0x1E
+REG_SLOTB_CH2_OFFSET    = 0x1F
+REG_SLOTB_CH3_OFFSET    = 0x20
+REG_SLOTB_CH4_OFFSET    = 0x21
+REG_ILED3_COARSE        = 0x22
+REG_ILED1_COARSE        = 0x23
+REG_ILED2_COARSE        = 0x24
+REG_ILED_FINE           = 0x25
+REG_SLOTA_LED_PULSE     = 0x30
+REG_SLOTA_NUM_PULSES    = 0x31
+REG_SLOTB_LED_PULSE     = 0x35
+REG_SLOTB_NUM_PULSES    = 0x36
+REG_SLOTA_AFE_WINDOW    = 0x39
+REG_SLOTB_AFE_WINDOW    = 0x3B
+REG_AFE_PWR_CFG1        = 0x3C
+REG_SLOTA_TIA_CFG       = 0x42
+REG_SLOTA_AFE_CFG       = 0x43
+REG_SLOTB_TIA_CFG       = 0x44
+REG_SLOTB_AFE_CFG       = 0x45
+REG_AFE_PWR_CFG2        = 0x54
+REG_MATH                = 0x58
+REG_DATA_ACCESS_CTL     = 0x5F
+REG_SLOTA_CH1           = 0x64
+REG_SLOTA_CH2           = 0x65
+REG_SLOTA_CH3           = 0x66
+REG_SLOTA_CH4           = 0x67
 
-# Helper: set register page
-REG_PAGE_SEL = 0x000F
-
-def set_page(bus, page):
-    bus.write_i2c_block_data(I2C_ADDR, REG_PAGE_SEL >> 8, [REG_PAGE_SEL & 0xFF, 0x00, page])
-    time.sleep(0.01)
-
-# Helper: write 16-bit to 16-bit register
-from smbus2 import i2c_msg
+# Basic register helpers
 
 def write_reg16(bus, reg, value):
-    data = [reg >> 8, reg & 0xFF, value >> 8, value & 0xFF]
-    msg = i2c_msg.write(I2C_ADDR, data)
-    bus.i2c_rdwr(msg)
+    bus.write_i2c_block_data(I2C_ADDR, reg, [value >> 8, value & 0xFF])
 
-# Helper: read 16-bit from 16-bit register
+
 def read_reg16(bus, reg):
-    write = i2c_msg.write(I2C_ADDR, [reg >> 8, reg & 0xFF])
-    read = i2c_msg.read(I2C_ADDR, 2)
-    bus.i2c_rdwr(write, read)
-    res = list(read)
-    return (res[0] << 8) | res[1]
+    data = bus.read_i2c_block_data(I2C_ADDR, reg, 2)
+    return (data[0] << 8) | data[1]
+
+
+def set_bit(bus, reg, bit, val):
+    tmp = read_reg16(bus, reg)
+    if val:
+        tmp |= (1 << bit)
+    else:
+        tmp &= ~(1 << bit)
+    write_reg16(bus, reg, tmp)
+
+
+def soft_reset(bus):
+    write_reg16(bus, REG_SW_RESET, 0x0001)
+    time.sleep(0.1)
+
+
+def set_mode(bus, mode):
+    write_reg16(bus, REG_MODE, mode & 0x03)
+
+
+def default_cfg(bus):
+    sequence = [
+        (REG_SLOT_EN, 0x30A9),
+        (REG_FSAMPLE, 0x0200),
+        (REG_PD_LED_SELECT, 0x011D),
+        (REG_NUM_AVG, 0x0000),
+        (REG_INT_SEQ_A, 0x0009),
+        (REG_SLOTA_CH1_OFFSET, 0x0000),
+        (REG_SLOTA_CH2_OFFSET, 0x3FFF),
+        (REG_SLOTA_CH3_OFFSET, 0x3FFF),
+        (REG_SLOTA_CH4_OFFSET, 0x3FFF),
+        (REG_INT_SEQ_B, 0x0009),
+        (REG_SLOTB_CH1_OFFSET, 0x0000),
+        (REG_SLOTB_CH2_OFFSET, 0x3FFF),
+        (REG_SLOTB_CH3_OFFSET, 0x3FFF),
+        (REG_SLOTB_CH4_OFFSET, 0x3FFF),
+        (REG_ILED3_COARSE, 0x3539),
+        (REG_ILED1_COARSE, 0x3536),
+        (REG_ILED2_COARSE, 0x1530),
+        (REG_ILED_FINE, 0x630C),
+        (REG_SLOTA_LED_PULSE, 0x0320),
+        (REG_SLOTA_NUM_PULSES, 0x040E),
+        (REG_SLOTB_LED_PULSE, 0x0320),
+        (REG_SLOTB_NUM_PULSES, 0x040E),
+        (REG_SLOTA_AFE_WINDOW, 0x22F0),
+        (REG_SLOTB_AFE_WINDOW, 0x22F0),
+        (REG_AFE_PWR_CFG1, 0x31C6),
+        (REG_SLOTA_TIA_CFG, 0x1C34),
+        (REG_SLOTA_AFE_CFG, 0xADA5),
+        (REG_SLOTB_TIA_CFG, 0x1C34),
+        (REG_SLOTB_AFE_CFG, 0xADA5),
+        (REG_MATH, 0x0544),
+        (REG_AFE_PWR_CFG2, 0x0AA0),
+        (REG_DATA_ACCESS_CTL, 0x0007),
+    ]
+    for reg, val in sequence:
+        write_reg16(bus, reg, val)
+
+    set_mode(bus, 1)  # program mode
+    set_bit(bus, 0x4B, 7, 1)  # SAMPLE_CLK bit 7
+    set_bit(bus, REG_DATA_ACCESS_CTL, 0, 1)
+    set_bit(bus, REG_INT_MASK, 5, 0)
+    set_bit(bus, REG_INT_MASK, 6, 1)
+    set_bit(bus, REG_INT_MASK, 8, 1)
+    set_bit(bus, REG_GPIO_DRV, 0, 1)
+    set_bit(bus, REG_GPIO_DRV, 1, 1)
+    set_bit(bus, REG_GPIO_DRV, 2, 1)
+    write_reg16(bus, REG_SLOT_EN, 0x3001)
+    set_mode(bus, 2)  # normal mode
+
+
+def read_slot_a(bus):
+    # enable data access for slot A
+    set_bit(bus, REG_DATA_ACCESS_CTL, 1, 1)
+    values = [read_reg16(bus, reg) for reg in (REG_SLOTA_CH1, REG_SLOTA_CH2,
+                                               REG_SLOTA_CH3, REG_SLOTA_CH4)]
+    set_bit(bus, REG_DATA_ACCESS_CTL, 1, 0)
+    return values
+
 
 with SMBus(1) as bus:
     print("Initializing Smoke 2 Click (ADPD188BI)...")
-
-    # ----------------------
-    # PAGE 0x00 – Reset + Program Mode
-    # ----------------------
-    set_page(bus, 0x00)
-    write_reg16(bus, REG_SYS_CTL, 0x0002)  # Soft reset
-    time.sleep(0.1)
-    write_reg16(bus, REG_OP_MODE, 0x0002)  # Program mode
-    time.sleep(0.05)
-
-    # ----------------------
-    # PAGE 0x01 – LED + Signal Chain Config (Minimal Clock + LED Init)
-    # ----------------------
-    set_page(bus, 0x01)
-    time.sleep(0.01)
-    write_reg16(bus, 0x0100, 0x1010)  # Shorter pulse width
-    write_reg16(bus, 0x0101, 0x1010)  # Moderate LED current
-    write_reg16(bus, 0x0102, 0x0008)  # Fewer pulses
-    write_reg16(bus, 0x0103, 0x0001)  # Sample every cycle  # Sample freq
-    time.sleep(0.01)
-
-    write_reg16(bus, 0x0053, 0x0001)  # LED pulse count
-    write_reg16(bus, 0x0054, 0x0001)  # LED offset
-    write_reg16(bus, 0x0104, 0x0003)  # Minimal viable clock bits
-    val = read_reg16(bus, 0x0104)
-    print(f"Post-write clock register 0x0104: 0x{val:04X}")  # Clock settings
-
-    write_reg16(bus, 0x004F, 0x0030)  # IR + GREEN
-    write_reg16(bus, 0x0050, 0x0001)  # Repeat LED1
-    write_reg16(bus, 0x0051, 0x0001)  # Repeat LED2
-    write_reg16(bus, 0x0052, 0x0001)  # Repeat LED3
-    time.sleep(0.01)
-
-    # ----------------------
-    # SLOT A Setup
-    # ----------------------
-    write_reg16(bus, 0x0110, 0x0010)  # Slot A Start
-    write_reg16(bus, 0x0111, 0x0040)  # Slot A End
-    write_reg16(bus, 0x0112, 0x0003)  # Enable Ch1 + Ch2
-    write_reg16(bus, 0x0040, 0x0001)  # Enable Slot A
-
-    # ----------------------
-    # PAGE 0x02 – AFE + Offset
-    # ----------------------
-    set_page(bus, 0x02)
-    time.sleep(0.01)
-    write_reg16(bus, 0x0200, 0x0000)  # AFE offset
-    write_reg16(bus, 0x0201, 0x0002)  # Gain = 100k
-
-    # ----------------------
-    # PAGE 0x01 – FIFO, Interrupt, Output Buffers
-    # ----------------------
-    set_page(bus, 0x01)
-    time.sleep(0.01)
-    write_reg16(bus, 0x0004, 0x0019)  # FIFO config
-    write_reg16(bus, 0x0006, 0x0400)  # Decimation
-    write_reg16(bus, 0x010A, 0x0000)  # Force register mode instead of FIFO  # Output buffer config
-    write_reg16(bus, 0x010B, 0x0001)
-    write_reg16(bus, 0x0020, 0x8000)  # Clear INT mask
-    write_reg16(bus, 0x0021, 0x8000)  # Clear INT status
-    print(f"REG_PAGE_SEL before MODE write: 0x{read_reg16(bus, REG_PAGE_SEL):04X}")
-    write_reg16(bus, REG_SYS_CTL, 0x0002)  # Soft reset again before mode set
-
-    # ----------------------
-    # PAGE 0x00 – Start Sampling
-    # ----------------------
-    set_page(bus, 0x00)
-    time.sleep(0.01)
-    write_reg16(bus, REG_OP_MODE, 0x0001)  # Normal sampling
-    time.sleep(0.1)
-
-    # ----------------------
-    # Begin Readout
-    # ----------------------
-    set_page(bus, 0x02)
-    print("Reading Smoke Sensor Values:")
-    current_mode = read_reg16(bus, REG_OP_MODE)
-    print(f"REG_OP_MODE current value: 0x{current_mode:04X}")
-    fifo_count = read_reg16(bus, 0x0000)
-    print(f"FIFO Samples (from 0x0000 upper byte): {(fifo_count >> 8) & 0xFF}")
-    int_status = read_reg16(bus, 0x0021)
-    print(f"INT_STATUS: 0x{int_status:04X}")
-    print("Reading registers 0x0064 to 0x0067...")
+    soft_reset(bus)
+    set_mode(bus, 0)  # idle
+    devid = read_reg16(bus, 0x08)
+    print(f"Device ID: 0x{devid:04X}")
+    default_cfg(bus)
+    print("Starting readout...")
 
     while True:
         try:
-            set_page(bus, 0x01)
-            time.sleep(0.05)
-            for reg in range(0x0064, 0x0068):
-                val = read_reg16(bus, reg)
-                print(f"0x{reg:04X}: {val}", end='  ')
-            print("")
+            vals = read_slot_a(bus)
+            print("CH1=%d  CH2=%d  CH3=%d  CH4=%d" % tuple(vals))
         except Exception as e:
             print(f"Error reading sensor: {e}")
-
         time.sleep(2)
+


### PR DESCRIPTION
## Summary
- rewrite smoketest scripts to match MikroElektronika driver
- implement `default_cfg` using 8-bit register addresses
- add helper to read Slot A data continuously

## Testing
- `python3 -m py_compile smoketest-limited.py 06/smoketest.py 06/aqi5_test.py`


------
https://chatgpt.com/codex/tasks/task_e_686575e744bc832b8d72088759839caa