### PR TITLE
Restore proper page selection

### DIFF
--- a/06/aqi5_test.py
+++ b/06/aqi5_test.py
@@ -19,7 +19,7 @@ REG_CH2         = 0x0016
 REG_PAGE_SEL = 0x000F
 
 def set_page(bus, page):
-    bus.write_i2c_block_data(I2C_ADDR, REG_PAGE_SEL >> 8, [REG_PAGE_SEL & 0xFF, 0x00, page])
+    write_reg16(bus, REG_PAGE_SEL, page)
     time.sleep(0.01)
 
 # Helper: write 16-bit to 16-bit register
@@ -122,7 +122,8 @@ with SMBus(1) as bus:
 
     while True:
         try:
-            set_page(bus, 0x01)
+            # Page 0x00 contains the photodiode data registers
+            set_page(bus, 0x00)
             time.sleep(0.05)
             for reg in range(0x0064, 0x0068):
                 val = read_reg16(bus, reg)

--- a/06/smoketest.py
+++ b/06/smoketest.py
@@ -19,7 +19,7 @@ REG_CH2         = 0x0016
 REG_PAGE_SEL = 0x000F
 
 def set_page(bus, page):
-    bus.write_i2c_block_data(I2C_ADDR, REG_PAGE_SEL >> 8, [REG_PAGE_SEL & 0xFF, 0x00, page])
+    write_reg16(bus, REG_PAGE_SEL, page)
     time.sleep(0.01)
 
 # Helper: write 16-bit to 16-bit register
@@ -126,7 +126,8 @@ with SMBus(1) as bus:
 
     while True:
         try:
-            set_page(bus, 0x01)
+            # Page 0x00 contains the photodiode data registers
+            set_page(bus, 0x00)
             time.sleep(0.05)
             for reg in range(0x0064, 0x0068):
                 val = read_reg16(bus, reg)

--- a/smoketest-limited.py
+++ b/smoketest-limited.py
@@ -19,7 +19,7 @@ REG_CH2         = 0x0016
 REG_PAGE_SEL = 0x000F
 
 def set_page(bus, page):
-    bus.write_i2c_block_data(I2C_ADDR, REG_PAGE_SEL >> 8, [REG_PAGE_SEL & 0xFF, 0x00, page])
+    write_reg16(bus, REG_PAGE_SEL, page)
     time.sleep(0.01)
 
 # Helper: write 16-bit to 16-bit register
@@ -126,7 +126,8 @@ with SMBus(1) as bus:
 
     while True:
         try:
-            set_page(bus, 0x01)
+            # Page 0x00 contains the photodiode data registers
+            set_page(bus, 0x00)
             time.sleep(0.05)
             for reg in range(0x0064, 0x0068):
                 val = read_reg16(bus, reg)


### PR DESCRIPTION
## Summary
- revert earlier changes
- ensure set_page uses `write_reg16`
- make the readout loops switch to page 0x00 before accessing photodiode data

## Testing
- `python3 -m py_compile smoketest-limited.py 06/smoketest.py 06/aqi5_test.py`


------
https://chatgpt.com/codex/tasks/task_e_686575e744bc832b8d72088759839caa