### PR TITLE
Add system throttling info to health payload

### DIFF
--- a/firemark-reporter.py
+++ b/firemark-reporter.py
@@ -73,11 +73,19 @@ def collect_health():
         except:
             return None
 
+    def get_throttled():
+        try:
+            out = subprocess.check_output(["vcgencmd", "get_throttled"]).decode()
+            return out.strip().split("=")[1]
+        except:
+            return None
+
     return {
         "cpu_temp": get_temp(),
         "uptime": get_uptime(),
         "rssi": get_rssi(),
-        "latency_ms": get_latency()
+        "latency_ms": get_latency(),
+        "throttled": get_throttled()
     }
 
 def post_payload(data):


### PR DESCRIPTION
## Summary
- add helper to gather `vcgencmd get_throttled` output
- include throttling state in the health JSON data

## Testing
- `python -m py_compile firemark-reporter.py`


------
https://chatgpt.com/codex/tasks/task_e_687168a03c24832bb18b757a2c6ab976